### PR TITLE
Fix whitespace-after-literal clang warning

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
 ^compile_commands\.json$
+^\.cache$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^\.vscode$
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
+^compile_commands\.json$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,7 +79,6 @@ jobs:
           _R_CHECK_CRAN_INCOMING_: false
           _R_CHECK_FORCE_SUGGESTS_: false
         run: |
-          install.packages("wk")
           rcmdcheck::rcmdcheck("geos", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check_geos")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,6 +8,9 @@ on:
 
 name: R-CMD-check
 
+permissions:
+  contents: read
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -19,7 +22,6 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: '3.6'}
           - {os: windows-latest, r: '4.1'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
@@ -31,7 +33,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -43,7 +45,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: rcmdcheck, wk, vctrs, sf
 
       - uses: r-lib/actions/check-r-package@v2
 
@@ -66,7 +68,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Checkout paleolimbot/geos
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: paleolimbot/geos
           ref: master

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 docs
 configure.log
 .vscode
+.cache
+compile_commands.json

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: libgeos
 Title: Open Source Geometry Engine ('GEOS') C API
-Version: 3.11.1-2
-Authors@R: 
+Version: 3.11.1-3
+Authors@R:
     c(
       person(given = "Dewey",
              family = "Dunnington",
@@ -39,5 +39,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 URL: https://paleolimbot.github.io/libgeos/, https://github.com/paleolimbot/libgeos
 BugReports: https://github.com/paleolimbot/libgeos/issues
-Suggests: 
+Suggests:
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ License: LGPL (>= 2.1)
 Copyright: file COPYRIGHTS
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 URL: https://paleolimbot.github.io/libgeos/, https://github.com/paleolimbot/libgeos
 BugReports: https://github.com/paleolimbot/libgeos/issues
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# libgeos 3.11.1-3
+
+* Fix deprecated literal syntax (#22)
+
 # libgeos 3.11.1-2
 
 * Fix format arguments to `REprintf()`.
@@ -23,7 +27,7 @@
 
 * Update to GEOS 3.9.1 (#3).
 * Added an exported callable `libgeos_version_int()` that can be used
-  to resolve runtime/compile-time differences 
+  to resolve runtime/compile-time differences
   when loading the exported GEOS callables (#4).
 * Removed C++ helpers and simplified linking tests (#4).
 * Simplified pattern for removing references to `std::cerr` from
@@ -36,8 +40,8 @@
 
 # libgeos 3.8.1-3
 
-* Fixed warnings from the link-time optimizer, which reported naming 
-  conflicts between the C++ header types and the abstract C types 
+* Fixed warnings from the link-time optimizer, which reported naming
+  conflicts between the C++ header types and the abstract C types
   used in the header API.
 
 # libgeos 3.8.1-2

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,6 @@
 
 This submission fixes warnings as shown on the package check page.
 
-## Test environments
-
-* local R installation, MacOS R 4.2.0
-* GitHub actions: MacOS (R release), Windows (R oldrel and release), 
-  Ubuntu 20.04 (R release, R devel)
-* win-builder (devel)
-* `rhub::check_for_cran()`
-
 ## R CMD check results
 
 * checking installed package size ... NOTE

--- a/src/geos_include/nlohmann_json.hpp
+++ b/src/geos_include/nlohmann_json.hpp
@@ -25250,7 +25250,7 @@ if no parse error occurred.
 @since version 1.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator ""_json(const char* s, std::size_t n)
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -25269,7 +25269,7 @@ object if no parse error occurred.
 @since version 2.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }


### PR DESCRIPTION
As reported by CRAN:

```
Found the following significant warnings:
    ../src/geos_include/nlohmann_json.hpp:25253:35: warning: identifier '_json' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
    ../src/geos_include/nlohmann_json.hpp:25272:49: warning: identifier '_json_pointer' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  See ‘/home/hornik/tmp/R.check/r-devel-clang/Work/PKGS/libgeos.Rcheck/00install.out’ for details.
  * used C compiler: ‘Debian clang version 19.1.7 (1+b1)’
  * used C++ compiler: ‘Debian clang version 19.1.7 (1+b1)’
```